### PR TITLE
Add Semantic Scholar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# local data files
+/data/*.parquet
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The API can be used to fetch more information for each paper in the corpus.
 ---
 ## Text generation on Huggingface
 
-We fine-tuned the distilgpt2 model from huggingface using the full-text from this corpus. The model is trained for generation task.
+We fine-tuned the DistilGPT2 model from huggingface using the full-text from this corpus. The model is trained for generation task.
 
 Text Generation Demo : https://huggingface.co/shaurya0512/distilgpt2-finetune-acl22
 

--- a/code/semanticscholar_extra/add_attributes.py
+++ b/code/semanticscholar_extra/add_attributes.py
@@ -1,0 +1,26 @@
+"""
+TODO
+"""
+
+import pandas as pd
+import semanticscholar
+import argparse
+
+if __name__ == "__main__":
+    args = argparse.ArgumentParser()
+    args.add_argument(
+        "-di", "--data-in", default="data/acl_corpus_full-text.parquet",
+        help="Path to the input parquet file."
+    )
+    args.add_argument(
+        "-f", "--feature", nargs="+",
+        default=["url", "citation_count", "citations", "references", "authors", "year"],
+    )
+    args.add_argument(
+        "-do", "--data-out", default="data/acl_corpus_full-text-ss.parquet",
+        help="Path to the output parquet file."
+    )
+    args = args.parse_args()
+
+    data = pd.read_parquet(args.data_in)
+    print(data.describe())


### PR DESCRIPTION
This isn't a merge-ready PR but just a stub to allow for a discussion. My idea of adding Semantic Scholar to this project is to have a script that reads in the `.parquet` file and produces a new `.parquet` file, with Semantic Scholar information (url, citation_count, citations, references, authors, year).

This would resolve some of the TODOs in the README (5, 6 and partially 1, 4). 

Let me know if this is how @shauryr would envision it so that I can continue with the implementation.