### PR TITLE
Rudimentary statistics for the dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ allen_ai_shaurya/requirements.txt
 allen_ai_shaurya/README.md
 allen_ai_shaurya/results.json
 allen_ai_shaurya/run.sh
+
+# added by zouharvi
+data/*.parquet

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository provides full-text and metadata to the ACL anthology collection 
 
 The goal is to keep this corpus updated and provide a comprehensive repository of the full ACL collection.
 
-This repository provides data for `80,013` ACL articles/posters -
+This repository provides data for `73,285` ACL articles/posters -
 
 1. 📖 All PDFs in ACL anthology : **size 45G**  [download here](https://drive.google.com/file/d/1OGHyJrkaVpbrdbmxsDotG-tI3LiKyxuC/view?usp=sharing)
 2. 🎓 All bib files in ACL anthology with abstracts : **size 172M** [download here](https://drive.google.com/file/d/1dJ-iE85moBv3iYG2LhRLT6KQyVkmllBg/view?usp=sharing)
@@ -71,6 +71,21 @@ The  provided ACL id is consistent with S2 API as well -
 The API can be used to fetch more information for each paper in the corpus.
 
 ---
+
+## Dataset Statistics
+
+<!-- Run code/statistics/main.py to get information for this table -->
+
+- **Total rows**: 73285
+- **Total unique & valid rows**: 63422
+- **Language distribution**: en 62308 (96.5%), fr 2037 (3.2%), pt 54 (0.1%), cy 25, ca 17, fi 14, no 11, de 10, ko 10, ... (long tail of less-represented languages)
+- **Average sents (words) per abstract**: 5.7 (140.5)
+- **Average sents (words) per paper text**: 159.0 (4264.7)
+- **Average words per title**: 10.4
+- **Total sents/words**: 11mil (284mil)
+- **Average number of authors**: 3.2
+- **Average number of citations**: 35.4
+- **Average number of pages per paper**: 9.2
 
 ## Text generation on Huggingface
 

--- a/code/statistics/main.py
+++ b/code/statistics/main.py
@@ -12,106 +12,107 @@ from collections import Counter
 from nltk.tokenize import sent_tokenize, word_tokenize
 import numpy as np
 
-if __name__ == "__main__":
-    args = argparse.ArgumentParser()
-    args.add_argument(
-        "-d", "--data", default="data/acl-publication-info.74k.parquet",
-        help="Path to the input parquet file."
-    )
-    args.add_argument(
-        "-t", "--total", type=int, default=None,
-        help="How many rows to consider (for fast development)."
-    )
-    args = args.parse_args()
-    data = pd.read_parquet(args.data)
+args = argparse.ArgumentParser()
+args.add_argument(
+    "-d", "--data", default="data/acl-publication-info.74k.parquet",
+    help="Path to the input parquet file."
+)
+args.add_argument(
+    "-t", "--total", type=int, default=None,
+    help="How many rows to consider (for fast development)."
+)
+args = args.parse_args()
+data = pd.read_parquet(args.data)
 
-    unique_hash = set()
-    langs = []
-    sent_counts_abstract = []
-    word_counts_abstract = []
-    sent_counts_paper = []
-    word_counts_paper = []
-    word_counts_title = []
-    citedby_paper = []
-    author_counts_paper = []
-    pages_counts_paper = []
+unique_hash = set()
+langs = []
+sent_counts_abstract = []
+word_counts_abstract = []
+sent_counts_paper = []
+word_counts_paper = []
+word_counts_title = []
+citedby_paper = []
+author_counts_paper = []
+pages_counts_paper = []
 
-    for row_i, row in tqdm.tqdm(
-        data[:args.total].iterrows(),
-        total=args.total if args.total is not None else data.shape[0]
-    ):
-        # if any row has title/abstract/full_text empty, consider it invalid
-        if len(row["title"].strip()) == 0 or len(row["abstract"].strip()) == 0 or len(row["full_text"].strip()) == 0:
-            continue
+# main loop to aggregate stats
+for row_i, row in tqdm.tqdm(
+    data[:args.total].iterrows(),
+    total=args.total if args.total is not None else data.shape[0]
+):
+    # if any row has title/abstract/full_text empty, consider it invalid
+    if len(row["title"].strip()) == 0 or len(row["abstract"].strip()) == 0 or len(row["full_text"].strip()) == 0:
+        continue
 
-        # disregard all papers if they have the same title and abstract
-        row_hash = f'{row["title"]} ||| {row["abstract"]}'
-        if row_hash in unique_hash:
-            continue
-        unique_hash.add(row_hash)
+    # disregard all papers if they have the same title and abstract
+    row_hash = f'{row["title"]} ||| {row["abstract"]}'
+    if row_hash in unique_hash:
+        continue
+    unique_hash.add(row_hash)
 
-        # detect and store language
-        lang_abstract = langdetect.detect(row["abstract"])
-        langs.append(lang_abstract)
+    # detect and store language
+    lang_abstract = langdetect.detect(row["abstract"])
+    langs.append(lang_abstract)
 
-        # Fulltext starts with the abstract. We can either assume that all paper texts start with "Introduction"
-        # (which is false in general) or just use the offset of the abstract.
-        fulltext_without_abstract = row["full_text"][len(row["abstract"]):]
+    # Fulltext starts with the abstract. We can either assume that all paper texts start with "Introduction"
+    # (which is false in general) or just use the offset of the abstract.
+    fulltext_without_abstract = row["full_text"][len(row["abstract"]):]
 
-        # store sent/word counts
-        sent_counts_abstract.append(len(sent_tokenize(row["abstract"])))
-        word_counts_abstract.append(len(word_tokenize(row["abstract"])))
-        sent_counts_paper.append(len(sent_tokenize(fulltext_without_abstract)))
-        word_counts_paper.append(len(word_tokenize(fulltext_without_abstract)))
-        word_counts_title.append(len(word_tokenize(row["title"])))
-        citedby_paper.append(row["numcitedby"])
+    # store sent/word counts
+    sent_counts_abstract.append(len(sent_tokenize(row["abstract"])))
+    word_counts_abstract.append(len(word_tokenize(row["abstract"])))
+    sent_counts_paper.append(len(sent_tokenize(fulltext_without_abstract)))
+    word_counts_paper.append(len(word_tokenize(fulltext_without_abstract)))
+    word_counts_title.append(len(word_tokenize(row["title"])))
+    citedby_paper.append(row["numcitedby"])
 
-        # sometimes authors are not available
-        if row["author"] is not None:
-            author_counts_paper.append(row["author"].count(" and")+1)
+    # sometimes authors are not available
+    if row["author"] is not None:
+        author_counts_paper.append(row["author"].count(" and") + 1)
 
-        # attempt to parse pages span
-        if row["pages"] is not None and "--" in row["pages"]:
-            pages = row["pages"].split("--")
-            try:
-                page_l = int(pages[0])
-                page_r = int(pages[1])
-                pages_total = page_r - page_l + 1
-                pages_counts_paper.append(pages_total)
-            except:
-                pass
+    # attempt to parse pages span
+    if row["pages"] is not None and "--" in row["pages"]:
+        pages = row["pages"].split("--")
+        try:
+            page_l = int(pages[0])
+            page_r = int(pages[1])
+            pages_total = page_r - page_l + 1
+            pages_counts_paper.append(pages_total)
+        except:
+            pass
 
-    print("Langs:", ", ".join([
-        f"{l} {v} ({v/len(unique_hash):.1%})"
-        for l, v in Counter(langs).most_common()
-    ]))
-    print(f'{"Total:":>40}', data.shape[0])
-    print(f'{"Total unique & valid:":>40}', len(unique_hash))
-    print(
-        f'{"Average sents (words) per abstract:":>40}',
-        f"{np.average(sent_counts_abstract):.1f} ({np.average(word_counts_abstract):.1f})"
-    )
-    print(
-        f'{"Average sents (words) per paper:":>40}',
-        f"{np.average(sent_counts_paper):.1f} ({np.average(word_counts_paper):.1f})"
-    )
-    print(
-        f'{"Average words/title:":>40}',
-        f"{np.average(word_counts_title):.1f}"
-    )
-    print(
-        f'{"Total sents (words):":>40}',
-        f"{sum(sent_counts_abstract) + sum(sent_counts_paper)} ({sum(word_counts_abstract) + sum(word_counts_paper)})"
-    )
-    print(
-        f'{"Average number of authors:":>40}',
-        f"{np.average(author_counts_paper):.1f}"
-    )
-    print(
-        f'{"Average number of citations:":>40}',
-        f"{np.average(citedby_paper):.1f}"
-    )
-    print(
-        f'{"Average number of pages per paper:":>40}',
-        f"{np.average(pages_counts_paper):.1f}"
-    )
+# print all stats
+print("Langs:", ", ".join([
+    f"{l} {v} ({v/len(unique_hash):.1%})"
+    for l, v in Counter(langs).most_common()
+]))
+print(f'{"Total:":>40}', data.shape[0])
+print(f'{"Total unique & valid:":>40}', len(unique_hash))
+print(
+    f'{"Average sents (words) per abstract:":>40}',
+    f"{np.average(sent_counts_abstract):.1f} ({np.average(word_counts_abstract):.1f})"
+)
+print(
+    f'{"Average sents (words) per paper:":>40}',
+    f"{np.average(sent_counts_paper):.1f} ({np.average(word_counts_paper):.1f})"
+)
+print(
+    f'{"Average words/title:":>40}',
+    f"{np.average(word_counts_title):.1f}"
+)
+print(
+    f'{"Total sents (words):":>40}',
+    f"{sum(sent_counts_abstract) + sum(sent_counts_paper)} ({sum(word_counts_abstract) + sum(word_counts_paper)})"
+)
+print(
+    f'{"Average number of authors:":>40}',
+    f"{np.average(author_counts_paper):.1f}"
+)
+print(
+    f'{"Average number of citations:":>40}',
+    f"{np.average(citedby_paper):.1f}"
+)
+print(
+    f'{"Average number of pages per paper:":>40}',
+    f"{np.average(pages_counts_paper):.1f}"
+)

--- a/code/statistics/main.py
+++ b/code/statistics/main.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+"""
+Compute rudimentary dataset statistics such as sentence/word counts, valid examples and present languages.
+"""
+
+import pandas as pd
+import argparse
+import langdetect
+import tqdm
+from collections import Counter
+from nltk.tokenize import sent_tokenize, word_tokenize
+import numpy as np
+
+if __name__ == "__main__":
+    args = argparse.ArgumentParser()
+    args.add_argument(
+        "-d", "--data", default="data/acl-publication-info.74k.parquet",
+        help="Path to the input parquet file."
+    )
+    args.add_argument(
+        "-t", "--total", type=int, default=None,
+        help="How many rows to consider (for fast development)."
+    )
+    args = args.parse_args()
+    data = pd.read_parquet(args.data)
+
+    unique_hash = set()
+    langs = []
+    sent_counts_abstract = []
+    word_counts_abstract = []
+    sent_counts_paper = []
+    word_counts_paper = []
+    word_counts_title = []
+    citedby_paper = []
+    author_counts_paper = []
+    pages_counts_paper = []
+
+    for row_i, row in tqdm.tqdm(
+        data[:args.total].iterrows(),
+        total=args.total if args.total is not None else data.shape[0]
+    ):
+        # if any row has title/abstract/full_text empty, consider it invalid
+        if len(row["title"].strip()) == 0 or len(row["abstract"].strip()) == 0 or len(row["full_text"].strip()) == 0:
+            continue
+
+        # disregard all papers if they have the same title and abstract
+        row_hash = f'{row["title"]} ||| {row["abstract"]}'
+        if row_hash in unique_hash:
+            continue
+        unique_hash.add(row_hash)
+
+        # detect and store language
+        lang_abstract = langdetect.detect(row["abstract"])
+        langs.append(lang_abstract)
+
+        # Fulltext starts with the abstract. We can either assume that all paper texts start with "Introduction"
+        # (which is false in general) or just use the offset of the abstract.
+        fulltext_without_abstract = row["full_text"][len(row["abstract"]):]
+
+        # store sent/word counts
+        sent_counts_abstract.append(len(sent_tokenize(row["abstract"])))
+        word_counts_abstract.append(len(word_tokenize(row["abstract"])))
+        sent_counts_paper.append(len(sent_tokenize(fulltext_without_abstract)))
+        word_counts_paper.append(len(word_tokenize(fulltext_without_abstract)))
+        word_counts_title.append(len(word_tokenize(row["title"])))
+        citedby_paper.append(row["numcitedby"])
+
+        # sometimes authors are not available
+        if row["author"] is not None:
+            author_counts_paper.append(row["author"].count(" and")+1)
+
+        # attempt to parse pages span
+        if row["pages"] is not None and "--" in row["pages"]:
+            pages = row["pages"].split("--")
+            try:
+                page_l = int(pages[0])
+                page_r = int(pages[1])
+                pages_total = page_r - page_l + 1
+                pages_counts_paper.append(pages_total)
+            except:
+                pass
+
+    print("Langs:", ", ".join([
+        f"{l} {v} ({v/len(unique_hash):.1%})"
+        for l, v in Counter(langs).most_common()
+    ]))
+    print(f'{"Total:":>40}', data.shape[0])
+    print(f'{"Total unique & valid:":>40}', len(unique_hash))
+    print(
+        f'{"Average sents (words) per abstract:":>40}',
+        f"{np.average(sent_counts_abstract):.1f} ({np.average(word_counts_abstract):.1f})"
+    )
+    print(
+        f'{"Average sents (words) per paper:":>40}',
+        f"{np.average(sent_counts_paper):.1f} ({np.average(word_counts_paper):.1f})"
+    )
+    print(
+        f'{"Average words/title:":>40}',
+        f"{np.average(word_counts_title):.1f}"
+    )
+    print(
+        f'{"Total sents (words):":>40}',
+        f"{sum(sent_counts_abstract) + sum(sent_counts_paper)} ({sum(word_counts_abstract) + sum(word_counts_paper)})"
+    )
+    print(
+        f'{"Average number of authors:":>40}',
+        f"{np.average(author_counts_paper):.1f}"
+    )
+    print(
+        f'{"Average number of citations:":>40}',
+        f"{np.average(citedby_paper):.1f}"
+    )
+    print(
+        f'{"Average number of pages per paper:":>40}',
+        f"{np.average(pages_counts_paper):.1f}"
+    )


### PR DESCRIPTION
This PR adds a script to compute some basic statistics about the corpus and displays them in the README. It is as much as I can extract from the fields that are currently available. From NLP perspective I'd be mostly interested in the languages and number of sentences. Let me know if you have some more ideas about this.

Semi-related notes:
- I also updated the total row count based on what's in `data/acl-publication-info.74k.parquet`.
- A more standard approach to TODOs would be to use GitHub Issues and list them there, instead of having it in the README. This would make tracing progress easier and would also make the "title page" less cluttered. What do you think?
- S2 provides paper embeddings. We could do some fun stuff with that.